### PR TITLE
Extend .gitignore to exclude several kinds of artifacts and temporary…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,52 @@
-.gitignore
+######################
+# Generic
+######################
+# Directories #
+bin/
+workfiles/
+
+# Temps and Backups #
+tmp/
+*.tmp
+*.bak
+*.log
+*.swp
+
+# Package Files #
+*.db
+*.rar
+*.tar.gz
+*.zip
+
+# Windows
+Thumbs.db
+desktop.ini
+
+# OSX
+.DS_Store
+
+######################
+# Build
+######################
+# exclude build artifacts
+*.a
+*.o
+
+######################
+# Eclipse CDT
+######################
+/.metadata/
+/.settings/
+/.project
+# CDT-specific
+/Debug/
+/Release/
+/rc/
+.cproject
+
+######################
+# Project-specific
+######################
+# ignore the executable created in the top-level directory
 zr
 


### PR DESCRIPTION
… files which may appear in the project directories from OSes and IDE's.

The current make process generates object files (*.o) in the project top level directory, which are better ignored by Git. For the occasion I also added a number of other kind of files which, in my personal experience, may appear because of operating systems and/or IDE's or other development tasks.

As I am primarily a Java programmer and I primarily use Eclipse, I also added to `.gitignore` some files it may create. Entries for other IDE's may be added later.