### PR TITLE
Fix 3 compilation error under Ubuntu.

### DIFF
--- a/src/input/load_wagon_file.c
+++ b/src/input/load_wagon_file.c
@@ -23,7 +23,7 @@
 char *read_scaled_token(MSfile *msfile) ;
 int  init_rawenginenode(RawWagonNode *w)   ;
 //int  check_wheel_radii(RawWagonNode *w) ;
-char string[4096] ;
+static char string[4096] ;
 
 int read_raw_wagon_file(RawWagonNode *w){
 

--- a/src/input/sigscr.c
+++ b/src/input/sigscr.c
@@ -89,7 +89,7 @@ int    print_sigscr_node(nodeType *p)   ;
 int    yyparse(nodeType **sTree) ;
 void   yyset_in(FILE *sfile)     ;
 
-FILE   *yyin, *yyout ;
+extern FILE   *yyin, *yyout ;
 int    itree_depth   ;
 
 /*


### PR DESCRIPTION
Under some Ubuntu (or Ubuntu-derived) distributions (at least the Linux Mint 21.1 I use) some compilation errors occur (different compiler versions?)

This fix corrects these errors without affecting the other distros currently tested (primarily OpenSUSE 15.3)